### PR TITLE
Added state sub generator.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,3 @@
 Julien Castelain <jcastelain@gmail.com>
 Denis Ciccale <dciccale@gmail.com>
-
+Aidan Breen <aido179@yahoo.com>

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ A [Yeoman](http://yeoman.io/) generator to generate HTML5 games with [phaser](ht
 + Invoke the generator:
 
   `yo phaser`
+  
++ Add new Phaser state (optional, generator creates basic initial states):
+  
+  `yo phaser:state`
+  
+  *You will be asked for a new state name.*
 
 + Run a local development server (livereload enabled) with this command:
 

--- a/app/templates/src/index.html
+++ b/app/templates/src/index.html
@@ -25,6 +25,7 @@
   <script src="js/menu.js"></script>
   <script src="js/game.js"></script>
   <script src="js/main.js"></script>
+  <!-- yo phaser:state new-state-files-put-here -->
   <!-- /build -->
 
 </body>

--- a/app/templates/src/js/main.js
+++ b/app/templates/src/js/main.js
@@ -9,6 +9,7 @@ window.onload = function () {
   game.state.add('preloader', ns.Preloader);
   game.state.add('menu', ns.Menu);
   game.state.add('game', ns.Game);
+  /* yo phaser:state new-state-files-put-here */
 
   game.state.start('boot');
 };

--- a/state/index.js
+++ b/state/index.js
@@ -1,0 +1,55 @@
+'use strict';
+var util = require('util');
+var yeoman = require('yeoman-generator');
+var chalk = require('chalk');
+
+
+var StateGenerator = yeoman.generators.Base.extend({
+  init: function () {
+    this.pkg = require('../package.json');
+    this.conflicter.force = true;
+    var localpkg = this.dest.readJSON('package.json');
+	this.projectName = localpkg.name;
+  },
+
+  askFor: function () {
+    var done = this.async();
+
+    this.log(chalk.magenta('... Phaser ...'));
+
+    var prompts = [{
+      type: 'input',
+      name: 'stateName',
+      message: 'What\'s the name of your new state?'
+    }];
+
+    this.prompt(prompts, function (props) {
+      this.stateName = props.stateName || ' ';
+      done();
+    }.bind(this));
+  },
+
+  state: function () {
+    //add new state js file from template
+    this.template('src/js/state.js', 'src/js/'+ this.stateName +'.js');
+    
+    //add reference to new state file to index.html
+    var path = "src/index.html",
+    file = this.readFileAsString(path),
+    needle = "<!-- yo phaser:state new-state-files-put-here -->";
+    file = file.replace(needle, '<script src="js/'+ this.stateName +'.js"></script>\n  '+needle);
+    this.write(path, file);
+
+    //add reference to main.js
+    path = "src/js/main.js";
+    file = this.readFileAsString(path);
+    needle = "/* yo phaser:state new-state-files-put-here */";
+    var stateNameCap = this.stateName.charAt(0).toUpperCase() + this.stateName.slice(1);
+    file = file.replace(needle, "game.state.add('"+this.stateName+"', ns."+stateNameCap+");\n  "+needle);
+    this.write(path, file);
+  }
+  
+});
+
+module.exports = StateGenerator;
+

--- a/state/templates/src/js/state.js
+++ b/state/templates/src/js/state.js
@@ -1,0 +1,31 @@
+(function() {
+  'use strict';
+
+  function <%= _.capitalize(stateName) %>() {
+    
+  }
+
+  <%= _.capitalize(stateName) %>.prototype = {
+
+    create: function () {
+    
+    },
+    update: function () {
+    
+    },
+    paused: function() {
+    
+    },
+    render: function() {
+    
+    },
+    shutdown: function() {
+    
+    }
+
+  };
+
+  window['<%= _.slugify(projectName) %>'] = window['<%= _.slugify(projectName) %>'] || {};
+  window['<%= _.slugify(projectName) %>'].<%= _.capitalize(stateName) %> = <%= _.capitalize(stateName) %>;
+
+}());


### PR DESCRIPTION
Added a yeoman sub generator to create phaser states that tie in with the generator-phaser framework layout.

The sub gen can be invoked as:
  `yo phaser:state`
and the sub gen will then ask for the name of the new state to create. 

The index.html and the main.js templates had to be updated to allow adding new references to the created state javascript files. There may be a more elegant way of accomplishing this.

Finally, I have not included unit tests for this code as I am unfamiliar with the unit testing framework. 