### PR TITLE
Fix processhtml options

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -58,7 +58,7 @@ gulp.task('minifycss', ['clean'], function () {
 
 gulp.task('processhtml', ['clean'], function() {
   gulp.src('src/index.html')
-    .pipe(processhtml('index.html'))
+    .pipe(processhtml({}))
     .pipe(gulp.dest(paths.dist))
     .on('error', gutil.log);
 });


### PR DESCRIPTION
This fixes the 'TypeError: Cannot read property 'push' of undefined' that the processhtml task was causing.
Fix taken from https://github.com/nikhilmodak/gulp-ngdocs/issues/21

I also think your script is missing the dependency of https://www.npmjs.com/package/htmlprocessor which is used by gulp-processhtml, but not sure where to add that in package.json.