### PR TITLE
Fixed: Creation of "build/custom"

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -53,6 +53,7 @@ var PhaserGenerator = generators.Base.extend({
     this.prompt(prompts, function (props) {
       this.projectName = props.projectName || ' ';
       this.phaserBuild = props.phaserBuild || 'phaser.min.js';
+      this.customBuild = this.phaserBuild.indexOf("custom/") !== -1 ? true : false;
       done();
     }.bind(this));
   },

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "start":       "budo src/main.js:bundle.js --live",
-    "prebuild":    "mkdir -p build",
+    "prebuild":    "mkdir -p build<% if (customBuild) {%> && mkdir -p build/custom <%}%>",
     "build":       "npm run build:js && npm run build:css && npm run build:html && npm run copy:all",
     "build:js":    "browserify src/main.js | uglifyjs -cm > build/bundle.min.js",
     "build:css":   "cleancss css/main.css -o build/main.min.css",


### PR DESCRIPTION
Fixed: Creation of `build/custom` when choosing a custom build of Phaser.

It was not possible to run `npm run build` because the directory `build/custom` has been missed.