### PR TITLE
Adds a generator to make a template shader so you don't have to copy/…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.js]
+indent_size = 2

--- a/shader/index.js
+++ b/shader/index.js
@@ -6,45 +6,42 @@ var path = require('path');
 
 
 var ShaderGenerator = generators.Base.extend({
-  init: function () {
+  init: function() {
     this.log('Creating a new Shader.');
     this.projectName = this.config.get("projectName");
   },
 
-  askFor: function () {
-      var done = this.async();
-      var prompts = [
-          {
-              type: 'input',
-              name: 'shaderName',
-              message: 'What\'s the name of your new shader?',
-              filter: function(input){return path.basename(input, '.frag'); }, //remove the .frag file extension if it is there
-              validate: function(input) {
-                 if(input===""){
-                   return "Shader name cannot be empty";
-                 }/*
-                 else if(/[\^\&\'\@\{\}\[\]\,\$\=\!\#\(\)\.\%\+\~\?\s\ ]+$/.test(input)){ //test for illegal characters in filename
-                   return "Prefab name has invalid characters in file name"
-                 }*/
-                 else{
-                   return true;
-                 }
-              }
-            }
-      ];
-      this.prompt(prompts, function (props) {
-        //set global vars to prompt vars
-        this.shaderName = props.shaderName;
-        done();
-      }.bind(this));
+  askFor: function() {
+    var done = this.async();
+    var prompts = [{
+      type: 'input',
+      name: 'shaderName',
+      message: 'What\'s the name of your new shader?',
+      filter: function(input) {
+        return path.basename(input, '.frag');
+      }, //remove the .frag file extension if it is there
+      validate: function(input) {
+        if (input === "") {
+          return "Shader name cannot be empty";
+        }
+        else {
+          return true;
+        }
+      }
+    }];
+    this.prompt(prompts, function(props) {
+      //set global vars to prompt vars
+      this.shaderName = props.shaderName;
+      done();
+    }.bind(this));
   },
 
-  projectfiles: function () {
-      this.fs.copyTpl(
-        this.templatePath(path.join('shader.frag')),
-        this.destinationPath(path.join('src','shaders',this.shaderName+'.frag')),
-        this
-      );
+  projectfiles: function() {
+    this.fs.copyTpl(
+      this.templatePath(path.join('shader.frag')),
+      this.destinationPath(path.join('src', 'shaders', this.shaderName + '.frag')),
+      this
+    );
   }
 });
 

--- a/shader/index.js
+++ b/shader/index.js
@@ -1,0 +1,51 @@
+'use strict';
+var util = require('util');
+var generators = require('yeoman-generator');
+var fs = require('fs');
+var path = require('path');
+
+
+var ShaderGenerator = generators.Base.extend({
+  init: function () {
+    this.log('Creating a new Shader.');
+    this.projectName = this.config.get("projectName");
+  },
+
+  askFor: function () {
+      var done = this.async();
+      var prompts = [
+          {
+              type: 'input',
+              name: 'shaderName',
+              message: 'What\'s the name of your new shader?',
+              filter: function(input){return path.basename(input, '.frag'); }, //remove the .frag file extension if it is there
+              validate: function(input) {
+                 if(input===""){
+                   return "Shader name cannot be empty";
+                 }/*
+                 else if(/[\^\&\'\@\{\}\[\]\,\$\=\!\#\(\)\.\%\+\~\?\s\ ]+$/.test(input)){ //test for illegal characters in filename
+                   return "Prefab name has invalid characters in file name"
+                 }*/
+                 else{
+                   return true;
+                 }
+              }
+            }
+      ];
+      this.prompt(prompts, function (props) {
+        //set global vars to prompt vars
+        this.shaderName = props.shaderName;
+        done();
+      }.bind(this));
+  },
+
+  projectfiles: function () {
+      this.fs.copyTpl(
+        this.templatePath(path.join('shader.frag')),
+        this.destinationPath(path.join('src','shaders',this.shaderName+'.frag')),
+        this
+      );
+  }
+});
+
+module.exports = ShaderGenerator;

--- a/shader/templates/shader.frag
+++ b/shader/templates/shader.frag
@@ -3,6 +3,8 @@ precision mediump float;
 uniform float     time;
 uniform vec2      resolution;
 uniform vec2      mouse;
+varying vec2 vTextureCoord;
+uniform sampler2D uSampler;
 
 void main( void ) {
     // Shader code goes here

--- a/shader/templates/shader.frag
+++ b/shader/templates/shader.frag
@@ -1,0 +1,9 @@
+precision mediump float;
+
+uniform float     time;
+uniform vec2      resolution;
+uniform vec2      mouse;
+
+void main( void ) {
+    // Shader code goes here
+}

--- a/shader/templates/shader.frag
+++ b/shader/templates/shader.frag
@@ -1,11 +1,11 @@
 precision mediump float;
 
-uniform float     time;
-uniform vec2      resolution;
-uniform vec2      mouse;
+uniform float time;
+uniform vec2 resolution;
+uniform vec2 mouse;
 varying vec2 vTextureCoord;
 uniform sampler2D uSampler;
 
 void main( void ) {
-    // Shader code goes here
+
 }


### PR DESCRIPTION
I added a wholly new generator because these aren't JS, so they don't need to care about ES5/6. They're a little closer to asset files, really.

The .frag extension was chosen based on [this documentation](http://phaser.io/docs/2.6.2/Phaser.Loader.html#shader) (tl;dr: if you don't specify an extension when loading these from file, Phaser defaults to .frag). This is contrary to something like Unity that expects .shader. 

The template itself is a stripped down version of [this Phaser example](http://phaser.io/examples/v2/filters/mouse-ray) plus some other fields I've used in my shaders. It's nice to know what things you get for free. I'm still very new to shaders, so I don't know what I'm missing, or what defaults I'm giving that are really quite variable.